### PR TITLE
Add MongoDB support for upload caching and URL shortening; enhance inline search functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
      "requests~=2.32.4",
      "tdjson~=1.8.51",
      "ujson~=5.10.0",
+     "pymongo>=4.9.1",
 ]
 
 [project.license]

--- a/sample.env
+++ b/sample.env
@@ -5,3 +5,6 @@ API_KEY=
 API_URL=https://tgmusic.fallenapi.fun
 DOWNLOAD_PATH=database
 LOGGER_ID=-1002434755494
+MONGO_URI=
+MONGO_DB_NAME=sptubebot
+MONGO_UPLOADS_COLL=uploads_cache

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -32,7 +32,7 @@ class Telegram(Client):
             plugins=types.plugins.Plugins(folder="src/modules"),
             files_directory="",
             database_encryption_key="",
-            options={"ignore_background_updates": True},
+            options={"ignore_background_updates": False},
         )
 
         self._http_client = HttpClient()

--- a/src/config.py
+++ b/src/config.py
@@ -21,3 +21,8 @@ API_KEY = getenv("API_KEY")
 API_URL = getenv("API_URL")
 DOWNLOAD_PATH = getenv("DOWNLOAD_PATH", "database")
 LOGGER_ID = get_env_int("LOGGER_ID", -1002434755494)
+
+# MongoDB configuration
+MONGO_URI: Optional[str] = getenv("MONGO_URI")
+MONGO_DB_NAME: str = getenv("MONGO_DB_NAME", "sptubebot")
+MONGO_UPLOADS_COLL: str = getenv("MONGO_UPLOADS_COLL", "uploads_cache")

--- a/src/modules/start.py
+++ b/src/modules/start.py
@@ -108,6 +108,12 @@ async def welcome(c: Client, message: types.Message):
 
 
 
+@Client.on_message(filters=Filter.command("help"))
+async def help_cmd(c: Client, message: types.Message):
+    # Reuse the same menu as /start for consistency
+    await welcome(c, message)
+
+
 @Client.on_message(filters=Filter.command("privacy"))
 async def privacy_handler(_: Client, message: types.Message):
     await message.reply_text(

--- a/src/utils/_cache.py
+++ b/src/utils/_cache.py
@@ -91,6 +91,7 @@ class MongoUploadCache:
             file_id = doc.get("file_id") if doc else None
             if file_id:
                 self.hot_cache.set(key, file_id)
+            logger.info(f"MongoUploadCache.get: _id={key} hit={'yes' if file_id else 'no'}")
             return file_id
         except Exception as e:
             logger.warning(f"Mongo get failed for key={key}: {e}")
@@ -121,6 +122,7 @@ class MongoUploadCache:
                 {"$set": {"file_id": file_id, "msg_url": message_link}},
                 upsert=True,
             )
+            logger.info(f"MongoUploadCache.set: saved _id={key} file_id={'set' if bool(file_id) else 'missing'} msg_url={'set' if bool(message_link) else 'missing'}")
         except Exception as e:
             logger.warning(f"Mongo set failed for key={key}: {e}")
         finally:
@@ -151,7 +153,7 @@ def _build_instances():
             import pymongo  # noqa: F401
             upload = MongoUploadCache()
             short = MongoURLShortener()
-            logger.info("Using MongoDB for caches")
+            logger.info("Using MongoDB for upload cache; shortener is in-memory")
         else:
             raise RuntimeError("MONGO_URI not configured")
     except Exception as e:

--- a/src/utils/_cache.py
+++ b/src/utils/_cache.py
@@ -1,51 +1,165 @@
 import hashlib
+import logging
+from collections import OrderedDict
+from datetime import datetime
 from threading import RLock
 from typing import Dict, Optional
-from collections import OrderedDict
 
-# TODO: use mongo
-class UploadCache:
-    def __init__(self):
-        self.cache = OrderedDict()
+from src import config
 
-    def get(self, key: str) -> str | None:
+logger = logging.getLogger(__name__)
+
+
+class InMemoryUploadCache:
+    def __init__(self, max_items: int = 2000):
+        self.cache = OrderedDict()  # key -> file_id
+        self.meta: Dict[str, Dict[str, object]] = {}  # key -> refs
+        self.max_items = max_items
+
+    def get(self, key: str) -> Optional[str]:
         return self.cache.get(key)
 
-    def set(self, key: str, file_id: str) -> None:
+    def get_message_ref(self, key: str) -> Optional[Dict[str, object]]:
+        return self.meta.get(key)
+
+    def set(
+        self,
+        key: str,
+        file_id: str,
+        message_link: Optional[str] = None,
+        chat_id: Optional[int] = None,
+        message_id: Optional[int] = None,
+    ) -> None:
         self.cache[key] = file_id
+        if message_link or chat_id or message_id:
+            self.meta[key] = {
+                "message_link": message_link,
+                "chat_id": chat_id,
+                "message_id": message_id,
+            }
         self.cache.move_to_end(key)
-        if len(self.cache) > 2000:
-            self.cache.popitem(last=False)
+        if len(self.cache) > self.max_items:
+            # also drop meta for evicted key if exists
+            evicted_key, _ = self.cache.popitem(last=False)
+            self.meta.pop(evicted_key, None)
 
-upload_cache = UploadCache()
 
-class URLShortener:
-    def __init__(self):
+class InMemoryURLShortener:
+    def __init__(self, token_length: int = 10):
         self.url_map: Dict[str, str] = {}
         self._lock = RLock()
-        self._token_len = 10
+        self._token_len = token_length
 
     def encode_url(self, url: str) -> str:
-        """Stores the URL and returns a short token (default 10 characters)"""
         token = self._generate_short_token(url)
-
         with self._lock:
             self.url_map[token] = url
-
         return token
 
     def decode_url(self, token: str) -> Optional[str]:
-        """Retrieves the original URL using the token"""
         with self._lock:
             return self.url_map.get(token)
 
     def _generate_short_token(self, url: str) -> str:
-        """Creates a consistent short hash from the URL"""
-        # Create SHA-256 hash
         hash_obj = hashlib.sha256(url.encode())
         hex_digest = hash_obj.hexdigest()
-
-        # Return first N characters of the hex digest
         return hex_digest[:self._token_len]
 
-shortener = URLShortener()
+
+class MongoUploadCache:
+    def __init__(self):
+        from pymongo import ASCENDING, MongoClient
+
+        if not config.MONGO_URI:
+            raise RuntimeError("MONGO_URI is not set")
+
+        client = MongoClient(config.MONGO_URI)
+        db = client[config.MONGO_DB_NAME]
+        self.col = db[config.MONGO_UPLOADS_COLL]
+        # Ensure indexes: use _id as the unique identifier
+        # No extra indexes required beyond default _id
+
+        # Keep in-memory LRU as a tiny hot cache to reduce roundtrips
+        self.hot_cache = InMemoryUploadCache(max_items=512)
+
+    def get(self, key: str) -> Optional[str]:
+        hot = self.hot_cache.get(key)
+        if hot is not None:
+            return hot
+        try:
+            doc = self.col.find_one({"_id": key}, {"_id": 0, "file_id": 1})
+            file_id = doc.get("file_id") if doc else None
+            if file_id:
+                self.hot_cache.set(key, file_id)
+            return file_id
+        except Exception as e:
+            logger.warning(f"Mongo get failed for key={key}: {e}")
+            return None
+
+    def get_message_ref(self, key: str) -> Optional[Dict[str, object]]:
+        try:
+            doc = self.col.find_one({"_id": key}, {"_id": 0, "msg_url": 1})
+            if not doc:
+                return None
+            return {"message_link": doc.get("msg_url")}
+        except Exception as e:
+            logger.warning(f"Mongo get_message_ref failed for key={key}: {e}")
+            return None
+
+    def set(
+        self,
+        key: str,
+        file_id: str,
+        message_link: Optional[str] = None,
+        chat_id: Optional[int] = None,
+        message_id: Optional[int] = None,
+    ) -> None:
+        try:
+            # Only persist minimal fields: _id (track id), file_id, msg_url
+            self.col.update_one(
+                {"_id": key},
+                {"$set": {"file_id": file_id, "msg_url": message_link}},
+                upsert=True,
+            )
+        except Exception as e:
+            logger.warning(f"Mongo set failed for key={key}: {e}")
+        finally:
+            self.hot_cache.set(key, file_id)
+
+
+class MongoURLShortener:
+    def __init__(self, token_length: int = 10):
+        # Per schema baru: tidak menyimpan short URL di Mongo.
+        self._in_memory = InMemoryURLShortener(token_length=token_length)
+
+    def encode_url(self, url: str) -> str:
+        return self._in_memory.encode_url(url)
+
+    def decode_url(self, token: str) -> Optional[str]:
+        return self._in_memory.decode_url(token)
+
+
+def _build_instances():
+    """Build cache/shortener instances with Mongo if available, else in-memory."""
+    # Default fallbacks
+    upload: InMemoryUploadCache | MongoUploadCache
+    short: InMemoryURLShortener | MongoURLShortener
+
+    try:
+        if config.MONGO_URI:
+            # Delay import so environments without pymongo still run
+            import pymongo  # noqa: F401
+            upload = MongoUploadCache()
+            short = MongoURLShortener()
+            logger.info("Using MongoDB for caches")
+        else:
+            raise RuntimeError("MONGO_URI not configured")
+    except Exception as e:
+        logger.warning(f"Falling back to in-memory caches: {e}")
+        upload = InMemoryUploadCache()
+        short = InMemoryURLShortener()
+
+    return upload, short
+
+
+upload_cache, shortener = _build_instances()


### PR DESCRIPTION
Implement MongoDB for upload_cache:

Schema: _id = track_id, store only file_id and msg_url.
Read MONGO_URI from .env; use MONGO_DB_NAME and MONGO_UPLOADS_COLL.
In-memory hot cache remains to reduce roundtrips.


Inline flow improvements:

When file_id is invalid, fallback via chat_id/message_id or msg_url (getMessageLinkInfo → getMessage), then update cache with new file_id.
Fix answerInlineQuery calls and empty results handling.
Store msg_url using getMessageLink; fallback to t.me/c/... format if needed.


Short URL not stored in DB (in-memory only).
Update configuration and dependencies:

Add pymongo to dependencies.
sample.env: add MONGO_URI, MONGO_DB_NAME, MONGO_UPLOADS_COLL; remove unused short-url variables.



🎯 Motivation/Rationale

Persistent cache across restarts.
Higher reliability: if file_id is corrupted/missing, can recover via msg_url.
Reduce bot overhead for re-uploading identical files.

🔧 Key Changes

src/utils/_cache.py: Minimal Mongo upload cache (_id, file_id, msg_url), in-memory fallback.
src/modules/inline.py: Fix answerInlineQuery, fallback audio sending via msg_url, store msg_url with getMessageLink.
src/modules/start.py: /help handler.
src/config.py + sample.env: Only variables for upload cache; short-url DB removed.
pyproject.toml: Add pymongo.

🧪 Testing Instructions

Setup .env:

MONGO_URI, MONGO_DB_NAME (optional), MONGO_UPLOADS_COLL (optional).


Run bot, perform inline search and select item:

Collection document uploads_cache should be created:
json{ "_id": "<track_id>", "file_id": "<telegram_file_id>", "msg_url": "https://t.me/..." }



Test fallback:

Simulate invalid file_id, select same item → bot uses msg_url to resolve and update file_id.


Send /help → should display help menu.

🔄 Compatibility Notes

No public API changes.
Existing collections (if any) should be cleaned/adapted to new minimal schema.