### PR TITLE
cache to db and add support for  yt-dlp 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ dependencies = [
      "httpx>=0.28.1",
      "pycryptodome>=3.23.0",
      "pydantic>=2.11.7",
+     "pymongo>=4.14.0",
      "pytdbot>=0.9.5",
      "python-dotenv>=1.1.1",
-     "requests~=2.32.4",
      "tdjson~=1.8.51",
      "ujson~=5.10.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
      "python-dotenv>=1.1.1",
      "tdjson~=1.8.51",
      "ujson~=5.10.0",
+     "yt-dlp>=2025.7.21",
 ]
 
 [project.license]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -22,6 +22,7 @@ StartTime = datetime.now()
 
 class Telegram(Client):
     def __init__(self) -> None:
+        self._check_config()
         super().__init__(
             token=config.TOKEN,
             api_id=config.API_ID,
@@ -48,5 +49,22 @@ class Telegram(Client):
         await db.close()
         await super().stop()
 
+    @staticmethod
+    def _check_config() -> None:
+        required_keys = [
+            "TOKEN",
+            "API_ID",
+            "API_HASH",
+            "API_KEY",
+            "API_URL",
+            "MONGO_URI",
+            "LOGGER_ID",
+        ]
+
+        missing = [key for key in required_keys if not getattr(config, key, None)]
+        if missing:
+            raise RuntimeError(
+                f"Missing required config values in .env: {', '.join(missing)}"
+            )
 
 client: Telegram = Telegram()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pytdbot import Client, types
 
 from src import config
-from src.utils import HttpClient
+from src.utils import HttpClient, db
 
 logging.basicConfig(
     level=logging.INFO,
@@ -41,9 +41,11 @@ class Telegram(Client):
         await self._http_client.get_client()
         await super().start()
         self.logger.info(f"Bot started in {datetime.now() - StartTime} seconds.")
+        await db.connect()
 
     async def stop(self) -> None:
         await self._http_client.close_client()
+        await db.close()
         await super().stop()
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -61,8 +61,9 @@ class Telegram(Client):
             "LOGGER_ID",
         ]
 
-        missing = [key for key in required_keys if not getattr(config, key, None)]
-        if missing:
+        if missing := [
+            key for key in required_keys if not getattr(config, key, None)
+        ]:
             raise RuntimeError(
                 f"Missing required config values in .env: {', '.join(missing)}"
             )

--- a/src/config.py
+++ b/src/config.py
@@ -11,6 +11,7 @@ def get_env_int(name: str, default: Optional[int] = None) -> Optional[int]:
     try:
         return int(value)
     except (TypeError, ValueError):
+        print(f"Invalid value for {name}: {value}")
         return default
 
 
@@ -20,4 +21,5 @@ TOKEN: Optional[str] = getenv("TOKEN")
 API_KEY = getenv("API_KEY")
 API_URL = getenv("API_URL")
 DOWNLOAD_PATH = getenv("DOWNLOAD_PATH", "database")
+MONGO_URI: Optional[str] = getenv("MONGO_URI")
 LOGGER_ID = get_env_int("LOGGER_ID", -1002434755494)

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,5 @@
 from os import getenv
+from pathlib import Path
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -20,6 +21,7 @@ API_HASH: Optional[str] = getenv("API_HASH")
 TOKEN: Optional[str] = getenv("TOKEN")
 API_KEY = getenv("API_KEY")
 API_URL = getenv("API_URL")
-DOWNLOAD_PATH = getenv("DOWNLOAD_PATH", "database")
+DOWNLOAD_PATH = Path(getenv("DOWNLOAD_PATH", "database/music"))
 MONGO_URI: Optional[str] = getenv("MONGO_URI")
 LOGGER_ID = get_env_int("LOGGER_ID", -1002434755494)
+COOKIES_URL: Optional[str] = getenv("COOKIES_URL")

--- a/src/modules/_utils.py
+++ b/src/modules/_utils.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from pytdbot import types, Client
+
 
 async def has_audio_stream(url: str) -> bool:
     cmd = [
@@ -26,3 +28,113 @@ async def has_audio_stream(url: str) -> bool:
         print(f"Error checking audio stream: {e}")
         return False
 
+async def handle_help_callback(_: Client, message: types.UpdateNewCallbackQuery):
+    data = message.payload.data.decode()
+    platform = data.replace("help_", "")
+
+    examples = {
+        "spotify": (
+            "💡<b>Spotify Downloader</b>\n\n"
+            "🔹 Download songs, albums, and playlists in 320kbps quality\n"
+            "🔹 Supports both public and private links\n\n"
+            "Example formats:\n"
+            "👉 <code>https://open.spotify.com/track/*</code> (Single song)\n"
+            "👉 <code>https://open.spotify.com/album/*</code> (Full album)\n"
+            "👉 <code>https://open.spotify.com/playlist/*</code> (Playlist)\n"
+            "👉 <code>https://open.spotify.com/artist/*</code> (Artist's top tracks)"
+        ),
+        "youtube": (
+            "💡<b>YouTube Downloader</b>\n\n"
+            "🔹 Download videos or extract audio\n"
+            "🔹 Supports both YouTube and YouTube Music links\n\n"
+            "Example formats:\n"
+            "👉 <code>https://youtu.be/*</code> (Short URL)\n"
+            "👉 <code>https://www.youtube.com/watch?v=*</code> (Full URL)\n"
+            "👉 <code>https://music.youtube.com/watch?v=*</code> (YouTube Music)"
+        ),
+        "soundcloud": (
+            "💡<b>SoundCloud Downloader</b>\n\n"
+            "🔹 Download tracks in high-quality\n"
+            "🔹 Supports both public and private tracks\n\n"
+            "Example formats:\n"
+            "👉 <code>https://soundcloud.com/user/track-name</code>\n"
+            "👉 <code>https://soundcloud.com/user/track-name?utm_source=*</code> (With tracking params)"
+        ),
+        "apple": (
+            "💡<b>Apple Music Downloader</b>\n\n"
+            "🔹 Lossless music downloads\n"
+            "🔹 Supports songs, albums, and artists\n\n"
+            "Example formats:\n"
+            "👉 <code>https://music.apple.com/*</code>\n"
+            "👉 <code>https://music.apple.com/us/song/*</code>\n"
+            "👉 <code>https://music.apple.com/us/album/*</code>\n"
+            "👉 <code>https://music.apple.com/us/artist/*</code>"
+        ),
+        "instagram": (
+            "💡<b>Instagram Media Downloader</b>\n\n"
+            "🔹 Download Instagram posts, reels, and stories\n"
+            "🔹 Supports both public and private accounts\n\n"
+            "Example formats:\n"
+            "👉 <code>https://www.instagram.com/p/*</code> (Posts)\n"
+            "👉 <code>https://www.instagram.com/reel/*</code> (Reels)\n"
+            "👉 <code>https://www.instagram.com/stories/*</code> (Stories\n)"
+           "Download Reels, Stories, and Posts:\n\n"
+            "👉 <code>https://www.instagram.com/reel/Cxyz123/</code>"
+        ),
+        "pinterest": (
+            "💡<b>Pinterest Downloader</b>\n\n"
+            "Photos and videos are available to download:\n\n"
+            "👉 <code>https://www.pinterest.com/pin/1085649053904273177/</code>"
+        ),
+        "facebook": (
+            "💡<b>Facebook Downloader</b>\n\n"
+            "Works with videos from public pages:\n\n"
+            "👉 <code>https://www.facebook.com/watch/?v=123456789</code>"
+        ),
+        "twitter": (
+            "💡<b>Twitter Downloader</b>\n\n"
+            "Download videos or Photos from posts:\n\n"
+            "👉 <code>https://x.com/i/status/1951310276814578086</code>\n"
+            "👉 <code>https://twitter.com/i/status/1951310276814578086</code>\n"
+            "👉 <code>https://x.com/luismbat/status/1951307858764607604/photo/1</code>"
+        ),
+        "tiktok": (
+            "💡<b>TikTok Downloader</b>\n\n"
+            "Supports watermark-free download:\n\n"
+            "👉 <code>https://vt.tiktok.com/ZSB3BovQp/</code>\n"
+            "👉 <code>https://vt.tiktok.com/ZSSe7NprD/</code>"
+        ),
+        "threads": (
+            "💡<b>Threads Downloader</b>\n\n"
+            "Download media from Threads:\n\n"
+            "👉 <code>https://www.threads.com/@camycavero/post/DM0FquaM2At?xmt=AQF0u_6ebeMHEjWCw0cm0Li4i8fI3INIU7YeSMffM9DmDw</code>\n"
+        ),
+        "reddit": (
+            "💡<b>Reddit Downloader</b>\n\n"
+            "Download media from Reddit:\n\n"
+            "👉 <code>https://www.reddit.com/r/tollywood/comments/1mld609/what_is_your_honest_unfiltered_opinion_on_mahesh/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button</code>\n"
+            "👉 <code>https://www.reddit.com/r/Damnthatsinteresting/comments/1mlfgzv/when_cat_meets_cat/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button</code>\n"
+            "👉 <code>https://www.reddit.com/r/Indian_flex/comments/1mlez7j/tough_life/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button</code>\n"
+        ),
+        "twitch": (
+            "💡<b>Twitch Clip Downloader</b>\n\n"
+            "Download media from Twitch:\n\n"
+            "👉 <code>https://www.twitch.tv/tarik/clip/CheerfulHonorableBibimbapHumbleLife-cdCV_zL45i1p2Kh6</code>\n"
+        ),
+    }
+
+    reply_text = examples.get(platform, "<b>No help available for this platform.</b>")
+    await message.answer(text="Help Menu")
+    await message.edit_message_text(
+        text=reply_text,
+        parse_mode="html",
+        disable_web_page_preview=True,
+        reply_markup=types.ReplyMarkupInlineKeyboard([
+            [
+                types.InlineKeyboardButton(
+                    text="⬅️ Back",
+                    type=types.InlineKeyboardButtonTypeCallback("back_menu".encode())
+                )
+            ]
+        ])
+    )

--- a/src/modules/callback.py
+++ b/src/modules/callback.py
@@ -61,12 +61,22 @@ async def callback_query(c: Client, message: types.UpdateNewCallbackQuery):
         c.logger.warning(f"❌ Failed to edit message: {msg.message}")
         return
 
-    reply_markup = types.ReplyMarkupInlineKeyboard([[
-        types.InlineKeyboardButton(
-            text=(track.name[:20] + '...' if len(track.name) > 20 else track.name),
-            type=types.InlineKeyboardButtonTypeUrl("https://t.me/FallenProjects"),
-        ),
-    ]])
+    reply_markup = types.ReplyMarkupInlineKeyboard(
+        [
+            [
+                types.InlineKeyboardButton(
+                    text=(
+                        f'{track.name[:20]}...'
+                        if len(track.name) > 20
+                        else track.name
+                    ),
+                    type=types.InlineKeyboardButtonTypeUrl(
+                        "https://t.me/FallenProjects"
+                    ),
+                )
+            ]
+        ]
+    )
     status_text = f"<b>🎵 {track.name}</b>\n👤 {track.artist} | 📀 {track.album}\n⏱️ {track.duration}s"
     parse = await c.parseTextEntities(status_text, types.TextParseModeHTML())
 
@@ -92,32 +102,30 @@ async def callback_query(c: Client, message: types.UpdateNewCallbackQuery):
                 await msg.edit_text("❌ Failed to send song to database.")
                 return
             audio = types.InputFileRemote(file_id)
-        else:
-            # Handle t.me link download for YouTube
-            if re.match(r"https?://t\.me/([^/]+)/(\d+)", audio_file):
-                info = await c.getMessageLinkInfo(audio_file)
-                if isinstance(info, types.Error) or not info.message:
-                    c.logger.error(f"❌ Failed to resolve link: {audio_file}")
-                    return
+        elif re.match(r"https?://t\.me/([^/]+)/(\d+)", audio_file):
+            info = await c.getMessageLinkInfo(audio_file)
+            if isinstance(info, types.Error) or not info.message:
+                c.logger.error(f"❌ Failed to resolve link: {audio_file}")
+                return
 
-                public_msg = await c.getMessage(info.chat_id, info.message.id)
-                if isinstance(public_msg, types.Error):
-                    c.logger.error(f"❌ Failed to fetch message: {public_msg.message}")
-                    await msg.edit_text(f"❌ Failed to fetch message: {public_msg.message}")
-                    return
+            public_msg = await c.getMessage(info.chat_id, info.message.id)
+            if isinstance(public_msg, types.Error):
+                c.logger.error(f"❌ Failed to fetch message: {public_msg.message}")
+                await msg.edit_text(f"❌ Failed to fetch message: {public_msg.message}")
+                return
 
-                if isinstance(public_msg.content, types.MessageAudio):
-                    audio = types.InputFileRemote(public_msg.content.audio.audio.remote.id)
-                elif isinstance(public_msg.content, types.MessageDocument):
-                    audio = types.InputFileRemote(public_msg.content.document.document.remote.id)
-                elif isinstance(public_msg.content, types.MessageVideo):
-                    audio = types.InputFileRemote(public_msg.content.video.video.remote.id)
-                else:
-                    c.logger.error(f"❌ No audio file in t.me link: {audio_file}")
-                    await msg.edit_text("⚠️ Audio file not found in t.me link")
-                    return
+            if isinstance(public_msg.content, types.MessageAudio):
+                audio = types.InputFileRemote(public_msg.content.audio.audio.remote.id)
+            elif isinstance(public_msg.content, types.MessageDocument):
+                audio = types.InputFileRemote(public_msg.content.document.document.remote.id)
+            elif isinstance(public_msg.content, types.MessageVideo):
+                audio = types.InputFileRemote(public_msg.content.video.video.remote.id)
             else:
-                audio = types.InputFileLocal(audio_file)
+                c.logger.error(f"❌ No audio file in t.me link: {audio_file}")
+                await msg.edit_text("⚠️ Audio file not found in t.me link")
+                return
+        else:
+            audio = types.InputFileLocal(audio_file)
 
     reply = await c.editMessageMedia(
         chat_id=message.chat_id,

--- a/src/modules/callback.py
+++ b/src/modules/callback.py
@@ -1,17 +1,23 @@
 import re
 from pytdbot import Client, types
 
-from src.utils import ApiData, Download, shortener
+from src.utils import ApiData, Download, shortener, db
 
+
+from ._utils import handle_help_callback
 
 @Client.on_updateNewCallbackQuery()
 async def callback_query(c: Client, message: types.UpdateNewCallbackQuery):
     data = message.payload.data.decode()
+    user_id = message.sender_user_id
+
+    # Help menu
     if data.startswith("help_"):
         await handle_help_callback(c, message)
         return
 
-    elif data == "back_menu":
+    # Back to main menu
+    if data == "back_menu":
         get_msg = await message.getMessage()
         if isinstance(get_msg, types.Error):
             c.logger.warning(f"❌ Failed to get message: {get_msg.message}")
@@ -22,7 +28,7 @@ async def callback_query(c: Client, message: types.UpdateNewCallbackQuery):
         await c.deleteMessages(message.chat_id, [message.message_id], revoke=True)
         return
 
-    user_id = message.sender_user_id
+    # Only handle spot_ callbacks
     if not data.startswith("spot_"):
         c.logger.warning(f"⚠️ Invalid callback data received: {data}")
         return
@@ -32,10 +38,8 @@ async def callback_query(c: Client, message: types.UpdateNewCallbackQuery):
         await message.answer("❌ Invalid callback format.", show_alert=True)
         return
 
-    id_enc = data[split1 + 1: split2]
-    uid = data[split2 + 1:]
-
-    if uid != "0" and uid != str(user_id):
+    id_enc, uid = data[split1 + 1: split2], data[split2 + 1:]
+    if uid not in ("0", str(user_id)):
         await message.answer("🚫 This button wasn't meant for you.", show_alert=True)
         return
 
@@ -44,10 +48,11 @@ async def callback_query(c: Client, message: types.UpdateNewCallbackQuery):
         await message.answer("⚠️ This button has expired. Please try again.", show_alert=True)
         return
 
+    # Get track info
     api = ApiData(url)
     track = await api.get_track()
     if isinstance(track, types.Error):
-        await message.answer(f"❌ Failed to fetch track info.\n<b>{track.message}</b>", show_alert=True)
+        await message.answer(f"❌ Failed to fetch track info.\n{track.message or 'Unknown error.'}", show_alert=True)
         return
 
     await message.answer("⏳ Processing your track, please wait...", show_alert=True)
@@ -56,51 +61,69 @@ async def callback_query(c: Client, message: types.UpdateNewCallbackQuery):
         c.logger.warning(f"❌ Failed to edit message: {msg.message}")
         return
 
-    dl = Download(track)
-    result = await dl.process()
-    if isinstance(result, types.Error):
-        await msg.edit_text(f"❌ Download failed.\n<b>{result.message}</b>")
-        return
-
-    audio_file, cover = result
-
-    # Handle t.me links (media already uploaded in a channel)
-    match = re.match(r"https?://t\.me/([^/]+)/(\d+)", audio_file)
-    if match:
-        info = await c.getMessageLinkInfo(audio_file)
-        if isinstance(info, types.Error) or info.message is None:
-            c.logger.error(f"❌ Failed to resolve link: {audio_file}")
-            return
-
-        dl_msg = await c.getMessage(info.chat_id, info.message.id)
-        if isinstance(dl_msg, types.Error):
-            c.logger.error(f"❌ Failed to fetch message: {dl_msg.message}")
-            return
-
-        file = await dl_msg.download()
-        if isinstance(file, types.Error):
-            c.logger.error(f"❌ Failed to download message ID {info.message.id}: {file.message}")
-            return
-
-        audio_file = file.path
-
+    reply_markup = types.ReplyMarkupInlineKeyboard([[
+        types.InlineKeyboardButton(
+            text=(track.name[:20] + '...' if len(track.name) > 20 else track.name),
+            type=types.InlineKeyboardButtonTypeUrl("https://t.me/FallenProjects"),
+        ),
+    ]])
     status_text = f"<b>🎵 {track.name}</b>\n👤 {track.artist} | 📀 {track.album}\n⏱️ {track.duration}s"
     parse = await c.parseTextEntities(status_text, types.TextParseModeHTML())
-    reply_markup = types.ReplyMarkupInlineKeyboard(
-        [
-            [
-                types.InlineKeyboardButton(
-                    text=f"{track.name[:20] + '...' if len(track.name) > 20 else track.name}",
-                    type=types.InlineKeyboardButtonTypeUrl("https://t.me/FallenProjects"),
-                ),
-            ],
-        ]
-    )
+
+    audio_file, cover, audio = None, None, None
+
+    # Spotify shortcut if file already cached
+    if track.platform.lower() == "spotify" and track.tc:
+        if file_id := await db.get_song_file_id(track.tc):
+            audio = types.InputFileRemote(file_id)
+
+    # Download if not found in DB
+    if not audio:
+        dl = Download(track)
+        result = await dl.process()
+        if isinstance(result, types.Error):
+            await msg.edit_text(f"❌ Download failed.\n<b>{result.message}</b>")
+            return
+
+        audio_file, cover = result
+        if track.platform.lower() == "spotify":
+            file_id = await db.upload_song_and_get_file_id(audio_file, cover, track)
+            if not file_id:
+                await msg.edit_text("❌ Failed to send song to database.")
+                return
+            audio = types.InputFileRemote(file_id)
+        else:
+            # Handle t.me link download for YouTube
+            if re.match(r"https?://t\.me/([^/]+)/(\d+)", audio_file):
+                info = await c.getMessageLinkInfo(audio_file)
+                if isinstance(info, types.Error) or not info.message:
+                    c.logger.error(f"❌ Failed to resolve link: {audio_file}")
+                    return
+
+                public_msg = await c.getMessage(info.chat_id, info.message.id)
+                if isinstance(public_msg, types.Error):
+                    c.logger.error(f"❌ Failed to fetch message: {public_msg.message}")
+                    await msg.edit_text(f"❌ Failed to fetch message: {public_msg.message}")
+                    return
+
+                if isinstance(public_msg.content, types.MessageAudio):
+                    audio = types.InputFileRemote(public_msg.content.audio.audio.remote.id)
+                elif isinstance(public_msg.content, types.MessageDocument):
+                    audio = types.InputFileRemote(public_msg.content.document.document.remote.id)
+                elif isinstance(public_msg.content, types.MessageVideo):
+                    audio = types.InputFileRemote(public_msg.content.video.video.remote.id)
+                else:
+                    c.logger.error(f"❌ No audio file in t.me link: {audio_file}")
+                    await msg.edit_text("⚠️ Audio file not found in t.me link")
+                    return
+            else:
+                audio = types.InputFileLocal(audio_file)
+
     reply = await c.editMessageMedia(
         chat_id=message.chat_id,
         message_id=message.message_id,
         input_message_content=types.InputMessageAudio(
-            audio=types.InputFileLocal(audio_file),
+            audio=audio,
             album_cover_thumbnail=types.InputThumbnail(types.InputFileLocal(cover)) if cover else None,
             title=track.name,
             performer=track.artist,
@@ -113,114 +136,3 @@ async def callback_query(c: Client, message: types.UpdateNewCallbackQuery):
     if isinstance(reply, types.Error):
         c.logger.error(f"❌ Failed to send audio file: {reply.message}")
         await msg.edit_text("❌ Failed to send the song. Please try again later.")
-
-async def handle_help_callback(_: Client, message: types.UpdateNewCallbackQuery):
-    data = message.payload.data.decode()
-    platform = data.replace("help_", "")
-
-    examples = {
-        "spotify": (
-            "💡<b>Spotify Downloader</b>\n\n"
-            "🔹 Download songs, albums, and playlists in 320kbps quality\n"
-            "🔹 Supports both public and private links\n\n"
-            "Example formats:\n"
-            "👉 <code>https://open.spotify.com/track/*</code> (Single song)\n"
-            "👉 <code>https://open.spotify.com/album/*</code> (Full album)\n"
-            "👉 <code>https://open.spotify.com/playlist/*</code> (Playlist)\n"
-            "👉 <code>https://open.spotify.com/artist/*</code> (Artist's top tracks)"
-        ),
-        "youtube": (
-            "💡<b>YouTube Downloader</b>\n\n"
-            "🔹 Download videos or extract audio\n"
-            "🔹 Supports both YouTube and YouTube Music links\n\n"
-            "Example formats:\n"
-            "👉 <code>https://youtu.be/*</code> (Short URL)\n"
-            "👉 <code>https://www.youtube.com/watch?v=*</code> (Full URL)\n"
-            "👉 <code>https://music.youtube.com/watch?v=*</code> (YouTube Music)"
-        ),
-        "soundcloud": (
-            "💡<b>SoundCloud Downloader</b>\n\n"
-            "🔹 Download tracks in high-quality\n"
-            "🔹 Supports both public and private tracks\n\n"
-            "Example formats:\n"
-            "👉 <code>https://soundcloud.com/user/track-name</code>\n"
-            "👉 <code>https://soundcloud.com/user/track-name?utm_source=*</code> (With tracking params)"
-        ),
-        "apple": (
-            "💡<b>Apple Music Downloader</b>\n\n"
-            "🔹 Lossless music downloads\n"
-            "🔹 Supports songs, albums, and artists\n\n"
-            "Example formats:\n"
-            "👉 <code>https://music.apple.com/*</code>\n"
-            "👉 <code>https://music.apple.com/us/song/*</code>\n"
-            "👉 <code>https://music.apple.com/us/album/*</code>\n"
-            "👉 <code>https://music.apple.com/us/artist/*</code>"
-        ),
-        "instagram": (
-            "💡<b>Instagram Media Downloader</b>\n\n"
-            "🔹 Download Instagram posts, reels, and stories\n"
-            "🔹 Supports both public and private accounts\n\n"
-            "Example formats:\n"
-            "👉 <code>https://www.instagram.com/p/*</code> (Posts)\n"
-            "👉 <code>https://www.instagram.com/reel/*</code> (Reels)\n"
-            "👉 <code>https://www.instagram.com/stories/*</code> (Stories\n)"
-           "Download Reels, Stories, and Posts:\n\n"
-            "👉 <code>https://www.instagram.com/reel/Cxyz123/</code>"
-        ),
-        "pinterest": (
-            "💡<b>Pinterest Downloader</b>\n\n"
-            "Photos and videos are available to download:\n\n"
-            "👉 <code>https://www.pinterest.com/pin/1085649053904273177/</code>"
-        ),
-        "facebook": (
-            "💡<b>Facebook Downloader</b>\n\n"
-            "Works with videos from public pages:\n\n"
-            "👉 <code>https://www.facebook.com/watch/?v=123456789</code>"
-        ),
-        "twitter": (
-            "💡<b>Twitter Downloader</b>\n\n"
-            "Download videos or Photos from posts:\n\n"
-            "👉 <code>https://x.com/i/status/1951310276814578086</code>\n"
-            "👉 <code>https://twitter.com/i/status/1951310276814578086</code>\n"
-            "👉 <code>https://x.com/luismbat/status/1951307858764607604/photo/1</code>"
-        ),
-        "tiktok": (
-            "💡<b>TikTok Downloader</b>\n\n"
-            "Supports watermark-free download:\n\n"
-            "👉 <code>https://vt.tiktok.com/ZSB3BovQp/</code>\n"
-            "👉 <code>https://vt.tiktok.com/ZSSe7NprD/</code>"
-        ),
-        "threads": (
-            "💡<b>Threads Downloader</b>\n\n"
-            "Download media from Threads:\n\n"
-            "👉 <code>https://www.threads.com/@camycavero/post/DM0FquaM2At?xmt=AQF0u_6ebeMHEjWCw0cm0Li4i8fI3INIU7YeSMffM9DmDw</code>\n"
-        ),
-        "reddit": (
-            "💡<b>Reddit Downloader</b>\n\n"
-            "Download media from Reddit:\n\n"
-            "👉 <code>https://www.reddit.com/r/tollywood/comments/1mld609/what_is_your_honest_unfiltered_opinion_on_mahesh/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button</code>\n"
-            "👉 <code>https://www.reddit.com/r/Damnthatsinteresting/comments/1mlfgzv/when_cat_meets_cat/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button</code>\n"
-            "👉 <code>https://www.reddit.com/r/Indian_flex/comments/1mlez7j/tough_life/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button</code>\n"
-        ),
-        "twitch": (
-            "💡<b>Twitch Clip Downloader</b>\n\n"
-            "Download media from Twitch:\n\n"
-            "👉 <code>https://www.twitch.tv/tarik/clip/CheerfulHonorableBibimbapHumbleLife-cdCV_zL45i1p2Kh6</code>\n"
-        ),
-    }
-
-    reply_text = examples.get(platform, "<b>No help available for this platform.</b>")
-    await message.answer(text="Help Menu")
-    await message.edit_message_text(
-        text=reply_text,
-        parse_mode="html",
-        disable_web_page_preview=True,
-        reply_markup=types.ReplyMarkupInlineKeyboard([
-            [
-                types.InlineKeyboardButton(
-                    text="⬅️ Back",
-                    type=types.InlineKeyboardButtonTypeCallback("back_menu".encode())
-                )
-            ]
-        ])
-    )

--- a/src/modules/inline.py
+++ b/src/modules/inline.py
@@ -134,13 +134,13 @@ async def inline_result(c: Client, message: types.UpdateNewChosenInlineResult):
 
         audio_file, cover = result
         file_id = await db.upload_song_and_get_file_id(audio_file, cover, track)
-        if not file_id:
-            error_text = await c.parseTextEntities("❌ Failed to send audio", types.TextParseModeHTML())
-            await c.editInlineMessageText(
-                inline_message_id=inline_message_id,
-                input_message_content=types.InputMessageText(error_text)
-            )
-            return
+    if not file_id:
+        error_text = await c.parseTextEntities("❌ Failed to send audio", types.TextParseModeHTML())
+        await c.editInlineMessageText(
+            inline_message_id=inline_message_id,
+            input_message_content=types.InputMessageText(error_text)
+        )
+        return
 
     # Send final audio
     edit_audio = await c.editInlineMessageMedia(
@@ -191,29 +191,30 @@ async def process_snap_inline(c: Client, message: types.UpdateNewInlineQuery, qu
         [
             [
                 types.InlineKeyboardButton(
-                    text=f"Search Again",
-                    type=types.InlineKeyboardButtonTypeSwitchInline(query=query, target_chat=types.TargetChatCurrent())
-                ),
-            ],
+                    text="Search Again",
+                    type=types.InlineKeyboardButtonTypeSwitchInline(
+                        query=query, target_chat=types.TargetChatCurrent()
+                    ),
+                )
+            ]
         ]
     )
 
-    for idx, image_url in enumerate(api_data.image or []):
-        if not image_url or not re.match("^https?://", image_url):
-            continue
-
-        results.append(
-            types.InputInlineQueryResultPhoto(
-                id=str(uuid.uuid4()),
-                photo_url=image_url,
-                thumbnail_url=image_url,
-                title=f"Photo {idx + 1}",
-                description=f"Image result #{idx + 1}",
-                input_message_content = types.InputMessagePhoto(photo=types.InputFileRemote(image_url)),
-                reply_markup=reply_markup
-            )
+    results.extend(
+        types.InputInlineQueryResultPhoto(
+            id=str(uuid.uuid4()),
+            photo_url=image_url,
+            thumbnail_url=image_url,
+            title=f"Photo {idx + 1}",
+            description=f"Image result #{idx + 1}",
+            input_message_content=types.InputMessagePhoto(
+                photo=types.InputFileRemote(image_url)
+            ),
+            reply_markup=reply_markup,
         )
-
+        for idx, image_url in enumerate(api_data.image or [])
+        if image_url and re.match("^https?://", image_url)
+    )
     for idx, video_data in enumerate(api_data.video or []):
         video_url = getattr(video_data, 'video', None)
         thumb_url = getattr(video_data, 'thumbnail', '')
@@ -236,7 +237,7 @@ async def process_snap_inline(c: Client, message: types.UpdateNewInlineQuery, qu
             )
         )
 
-    if len(results) == 0:
+    if not results:
         parse = await c.parseTextEntities("No media found for this query", types.TextParseModeHTML())
         results.append(
             types.InputInlineQueryResultArticle(

--- a/src/modules/inline.py
+++ b/src/modules/inline.py
@@ -4,8 +4,7 @@ from typing import Union
 
 from pytdbot import Client, types
 
-from src import config
-from src.utils import ApiData, Download, upload_cache, shortener, APIResponse
+from src.utils import ApiData, Download, shortener, APIResponse, db
 
 
 @Client.on_updateNewInlineQuery()
@@ -13,7 +12,9 @@ async def inline_search(c: Client, message: types.UpdateNewInlineQuery):
     query = message.query.strip()
     if not query:
         return None
+
     api = ApiData(query)
+
     if api.is_save_snap_url():
         return await process_snap_inline(c, message, query)
 
@@ -23,7 +24,7 @@ async def inline_search(c: Client, message: types.UpdateNewInlineQuery):
             message.id,
             results=[
                 types.InputInlineQueryResultArticle(
-                    id="error",
+                    id=str(uuid.uuid4()),
                     title="❌ Search Failed",
                     description=search.message or "Could not search Spotify.",
                 )
@@ -69,11 +70,7 @@ async def inline_search(c: Client, message: types.UpdateNewInlineQuery):
             )
         )
 
-    response = await c.answerInlineQuery(
-        message.id,
-        results=results,
-    )
-
+    response = await c.answerInlineQuery(message.id, results=results)
     if isinstance(response, types.Error):
         c.logger.warning(f"❌ Inline response error: {response.message}")
     return None
@@ -84,81 +81,69 @@ async def inline_result(c: Client, message: types.UpdateNewChosenInlineResult):
     result_id = message.result_id
     inline_message_id = message.inline_message_id
     if not inline_message_id:
-        return None
+        return
 
-    # Fetch track data
+    # Decode and validate URL
     url = shortener.decode_url(result_id)
     if not url:
-        return None
+        return
 
     api = ApiData(url)
     if api.is_save_snap_url():
-        return None
+        return
 
+    # Fetch track
     track = await api.get_track()
     if isinstance(track, types.Error):
-        return None
+        return
 
+    # Prepare and send "loading" status
     status_text = f"<b>🎵 {track.name}</b>\n👤 {track.artist} | 📀 {track.album}\n⏱️ {track.duration}s"
     parsed_status = await c.parseTextEntities(status_text, types.TextParseModeHTML())
     if isinstance(parsed_status, types.Error):
         c.logger.warning(f"❌ Text parse error: {parsed_status.message}")
-        return None
+        return
 
     await c.editInlineMessageText(
         inline_message_id=inline_message_id,
-        input_message_content=types.InputMessageText(parsed_status),
+        input_message_content=types.InputMessageText(parsed_status)
     )
 
-    dl = Download(track)
-    result = await dl.process()
-    if isinstance(result, types.Error):
-        error_text = await c.parseTextEntities(result.message, types.TextParseModeHTML())
-        await c.editInlineMessageText(
-            inline_message_id=inline_message_id,
-            input_message_content=types.InputMessageText(error_text),
-        )
-        return None
+    # Prepare caption
+    caption_text = f"<b>{track.name}</b>\n<i>{track.artist}</i>"
+    parsed_caption = await c.parseTextEntities(caption_text, types.TextParseModeHTML())
+    if isinstance(parsed_caption, types.Error):
+        c.logger.warning(f"❌ Caption parse error: {parsed_caption.message}")
+        parsed_caption = None
 
-    audio_file, cover = result
-    caption = f"<b>{track.name}</b>\n<i>{track.artist}</i>"
-    parsed_caption = await c.parseTextEntities(caption, types.TextParseModeHTML())
-    cached_file_id = upload_cache.get(track.tc)
-    if cached_file_id:
-        await c.editInlineMessageMedia(
-            inline_message_id=inline_message_id,
-            input_message_content=types.InputMessageAudio(
-                audio=types.InputFileRemote(cached_file_id),
-                album_cover_thumbnail=types.InputThumbnail(types.InputFileLocal(cover)) if cover else None,
-                title=track.name,
-                performer=track.artist,
-                duration=track.duration,
-                caption=parsed_caption,
-            ),
-        )
-        return None
+    # Get file_id or download
+    file_id, cover = None, None
+    if track.platform.lower() == "spotify":
+        file_id = await db.get_song_file_id(track.tc)
 
-    upload = await c.sendAudio(
-        chat_id=config.LOGGER_ID,
-        audio=types.InputFileLocal(audio_file),
-        album_cover_thumbnail=types.InputThumbnail(types.InputFileLocal(cover)) if cover else None,
-        title=track.name,
-        performer=track.artist,
-        duration=track.duration,
-        caption=caption,
-    )
+    if not file_id:
+        dl = Download(track)
+        result = await dl.process()
+        if isinstance(result, types.Error):
+            error_text = await c.parseTextEntities(result.message, types.TextParseModeHTML())
+            await c.editInlineMessageText(
+                inline_message_id=inline_message_id,
+                input_message_content=types.InputMessageText(error_text)
+            )
+            return
 
-    if isinstance(upload, types.Error):
-        fallback_text = await c.parseTextEntities(upload.message, types.TextParseModeHTML())
-        await c.editInlineMessageText(
-            inline_message_id=inline_message_id,
-            input_message_content=types.InputMessageText(fallback_text),
-        )
-        return None
+        audio_file, cover = result
+        file_id = await db.upload_song_and_get_file_id(audio_file, cover, track)
+        if not file_id:
+            error_text = await c.parseTextEntities("❌ Failed to send audio", types.TextParseModeHTML())
+            await c.editInlineMessageText(
+                inline_message_id=inline_message_id,
+                input_message_content=types.InputMessageText(error_text)
+            )
+            return
 
-    file_id = upload.content.audio.audio.remote.id
-    upload_cache.set(track.tc, file_id)
-    send_audio = await c.editInlineMessageMedia(
+    # Send final audio
+    edit_audio = await c.editInlineMessageMedia(
         inline_message_id=inline_message_id,
         input_message_content=types.InputMessageAudio(
             audio=types.InputFileRemote(file_id),
@@ -166,23 +151,19 @@ async def inline_result(c: Client, message: types.UpdateNewChosenInlineResult):
             title=track.name,
             performer=track.artist,
             duration=track.duration,
-            caption=parsed_caption,
+            caption=parsed_caption
         ),
     )
 
-    if isinstance(send_audio, types.Error):
-        c.logger.error(f"❌ Failed to send audio: {send_audio.message}")
-        fallback_text = await c.parseTextEntities(send_audio.message, types.TextParseModeHTML())
+    if isinstance(edit_audio, types.Error):
+        c.logger.error(f"❌ Failed to send audio: {edit_audio.message}")
+        fallback_text = await c.parseTextEntities(edit_audio.message, types.TextParseModeHTML())
         await c.editInlineMessageText(
             inline_message_id=inline_message_id,
-            input_message_content=types.InputMessageText(fallback_text),
+            input_message_content=types.InputMessageText(fallback_text)
         )
-        return None
-    return None
 
 
-def get_query_id():
-    return str(uuid.uuid4())
 
 async def process_snap_inline(c: Client, message: types.UpdateNewInlineQuery, query: str):
     api = ApiData(query)
@@ -195,7 +176,7 @@ async def process_snap_inline(c: Client, message: types.UpdateNewInlineQuery, qu
             inline_query_id=message.id,
             results=[
                 types.InputInlineQueryResultArticle(
-                    id=get_query_id(),
+                    id=str(uuid.uuid4()),
                     title="❌ Search Failed",
                     description="Something went wrong.",
                     input_message_content=types.InputMessageText(text=parse)
@@ -223,7 +204,7 @@ async def process_snap_inline(c: Client, message: types.UpdateNewInlineQuery, qu
 
         results.append(
             types.InputInlineQueryResultPhoto(
-                id=get_query_id(),
+                id=str(uuid.uuid4()),
                 photo_url=image_url,
                 thumbnail_url=image_url,
                 title=f"Photo {idx + 1}",
@@ -241,7 +222,7 @@ async def process_snap_inline(c: Client, message: types.UpdateNewInlineQuery, qu
 
         results.append(
             types.InputInlineQueryResultVideo(
-                id=get_query_id(),
+                id=str(uuid.uuid4()),
                 video_url=video_url,
                 mime_type="video/mp4",
                 thumbnail_url=thumb_url if thumb_url and re.match("^https?://", thumb_url) else "https://i.pinimg.com/736x/e2/c6/eb/e2c6eb0b48fc00f1304431bfbcacf50e.jpg",
@@ -259,7 +240,7 @@ async def process_snap_inline(c: Client, message: types.UpdateNewInlineQuery, qu
         parse = await c.parseTextEntities("No media found for this query", types.TextParseModeHTML())
         results.append(
             types.InputInlineQueryResultArticle(
-                id=get_query_id(),
+                id=str(uuid.uuid4()),
                 title="No media found",
                 description="Try a different search term",
                 input_message_content=types.InputMessageText(text=parse)
@@ -277,7 +258,7 @@ async def process_snap_inline(c: Client, message: types.UpdateNewInlineQuery, qu
             inline_query_id=message.id,
             results=[
                 types.InputInlineQueryResultArticle(
-                    id=get_query_id(),
+                    id=str(uuid.uuid4()),
                     title="❌ Search Failed",
                     description="Maybe Video size is too big.",
                     input_message_content=types.InputMessageText(text=done.message)

--- a/src/modules/start.py
+++ b/src/modules/start.py
@@ -89,12 +89,15 @@ def get_main_menu_keyboard(bot_username: str) -> types.ReplyMarkupInlineKeyboard
 @Client.on_message(filters=Filter.command(["start", "help"]))
 async def welcome(c: Client, message: types.Message):
     bot_username = c.me.usernames.editable_username
+    bot_name = c.me.first_name
     text = (
-        "<b>🎧 Welcome to SpTube Bot</b>\n"
-        "Easily download music & media from your favorite platforms.\n\n"
-        "📩 Send a name, link, or media URL\n"
-        f"🔎 Try inline: <code>@{bot_username} your search</code>\n\n"
-        "🔐 Privacy: /privacy"
+        f"<b>🎧 Welcome to {bot_name}!</b>\n"
+        "Your quick and easy tool to download music & media from top platforms.\n\n"
+        "📩 Just send a song name, link, or media URL.\n"
+        f"🔎 Search inline: <code>@{bot_username} your search</code>\n\n"
+        "🔐 Privacy policy: /privacy\n"
+        "📺 Download videos: /yt <code>url</code>\n"
+        "🎵 Get Spotify playlists: /playlist <code>url</code>\n"
     )
 
     reply = await message.reply_text(

--- a/src/modules/start.py
+++ b/src/modules/start.py
@@ -86,7 +86,7 @@ def get_main_menu_keyboard(bot_username: str) -> types.ReplyMarkupInlineKeyboard
 
 
 
-@Client.on_message(filters=Filter.command("start"))
+@Client.on_message(filters=Filter.command(["start", "help"]))
 async def welcome(c: Client, message: types.Message):
     bot_username = c.me.usernames.editable_username
     text = (
@@ -96,6 +96,7 @@ async def welcome(c: Client, message: types.Message):
         f"🔎 Try inline: <code>@{bot_username} your search</code>\n\n"
         "🔐 Privacy: /privacy"
     )
+
     reply = await message.reply_text(
         text,
         parse_mode="html",

--- a/src/modules/yt_dlp.py
+++ b/src/modules/yt_dlp.py
@@ -59,7 +59,7 @@ async def get_working_proxy():
                 r = await pclient.get("https://httpbin.org/ip")
                 if r.status_code == 200:
                     return proxy
-        except:
+        except Exception:
             continue
     return None
 

--- a/src/modules/yt_dlp.py
+++ b/src/modules/yt_dlp.py
@@ -1,0 +1,167 @@
+import asyncio
+import os
+import random
+import re
+
+import httpx
+from pytdbot import Client, types
+
+from src import LOGGER
+from src.config import COOKIES_URL, DOWNLOAD_PATH
+from src.utils import Filter, HttpClient
+
+
+async def get_cookies() -> str | None:
+    if not COOKIES_URL:
+        return None
+
+    if not COOKIES_URL.startswith("https://batbin.me/"):
+        LOGGER.error("Invalid cookies URL")
+        return None
+
+    paste_id = COOKIES_URL.strip("/").split("/")[-1]
+    file_path = f"database/cookies_{paste_id}.txt"
+
+    if os.path.exists(file_path):
+        return file_path
+
+    raw_url = f"https://batbin.me/raw/{paste_id}"
+    http_client = await HttpClient.get_client()
+    resp = await http_client.get(raw_url)
+    if resp.status_code != 200:
+        return None
+
+    os.makedirs("database", exist_ok=True)
+    with open(file_path, "w") as f:
+        f.write(resp.text)
+    return file_path
+
+
+async def get_working_proxy():
+    urls = {
+        "socks5": "https://raw.githubusercontent.com/olgavlncia/proxyhub/main/output/socks5.txt",
+        "http": "https://raw.githubusercontent.com/olgavlncia/proxyhub/main/output/http.txt",
+    }
+
+    async with httpx.AsyncClient(timeout=5) as client:
+        socks5_req, http_req = await asyncio.gather(
+            client.get(urls["socks5"]),
+            client.get(urls["http"]),
+        )
+
+        socks5_list = [f"socks5://{p.strip()}" for p in socks5_req.text.strip().split("\n")[-50:] if p.strip()]
+        http_list   = [f"http://{p.strip()}"   for p in http_req.text.strip().split("\n")[-50:] if p.strip()]
+        candidates = socks5_list + http_list
+
+    for proxy in random.sample(candidates, len(candidates)):
+        try:
+            async with httpx.AsyncClient(proxy=proxy, timeout=5) as pclient:
+                r = await pclient.get("https://httpbin.org/ip")
+                if r.status_code == 200:
+                    return proxy
+        except:
+            continue
+    return None
+
+
+@Client.on_message(filters=Filter.command(["yt", "youtube"]))
+async def youtube_cmd(c: Client, message: types.Message):
+    parts = message.text.split(" ", 1)
+    if len(parts) < 2:
+        await message.reply_text("Please provide a search query.")
+        return
+
+    query = parts[1]
+    if not re.match(r"^https?://", query):
+        await message.reply_text("Please provide a valid URL.")
+        return
+
+    is_yt_url = "youtube.com" in query.lower() or "youtu.be" in query.lower()
+    reply = await message.reply_text("🔍 Preparing download...")
+    output_template = str(DOWNLOAD_PATH / "%(title)s.%(ext)s")
+    c.logger.info(f"Downloading: {query}")
+    format_selector = "bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio/best"
+    ytdlp_params = [
+        "yt-dlp",
+        "--no-warnings",
+        "--no-playlist",
+        "--quiet",
+        "--geo-bypass",
+        "--retries", "2",
+        "--continue",
+        "--no-part",
+        "--concurrent-fragments", "3",
+        "--socket-timeout", "10",
+        "--throttled-rate", "100K",
+        "--retry-sleep", "1",
+        # "--no-write-thumbnail",
+        "--no-write-info-json",
+        "--no-embed-metadata",
+        "--no-embed-chapters",
+        "--no-embed-subs",
+        "--merge-output-format", "mp4",
+        "-o", output_template,
+        "-f", format_selector,
+        "--print", "after_move:filepath",
+        query
+    ]
+
+    if is_yt_url:
+        if cookie_file := await get_cookies():
+            ytdlp_params += ["--cookies", cookie_file]
+        else:
+            await reply.edit_text("Selecting a working proxy...")
+            proxy = await get_working_proxy()
+            if not proxy:
+                await reply.edit_text("❌ No working proxies found.")
+                return
+            if proxy:
+                ytdlp_params += ["--proxy", proxy]
+
+    proc = await asyncio.create_subprocess_exec(
+        *ytdlp_params,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=300)
+    except asyncio.TimeoutError:
+        await reply.edit_text("⏳ Download timed out.")
+        return
+
+    if proc.returncode != 0:
+        error_msg = stderr.decode().strip()
+        if "is not a valid URL" in error_msg:
+            await reply.edit_text("❌ Invalid URL provided. Please provide a valid video URL.")
+        else:
+            await reply.edit_text(f"❌ Error downloading:\n<code>{error_msg}</code>")
+        return
+
+    downloaded_path = stdout.decode().strip()
+    if not downloaded_path:
+        await reply.edit_text("❌ Could not find downloaded file.")
+        return
+
+    try:
+        if not os.path.exists(downloaded_path):
+            await reply.edit_text("❌ Downloaded file not found.")
+            return
+
+        done = await message.reply_video(
+            video=types.InputFileLocal(downloaded_path),
+            supports_streaming=True,
+            caption="This video automatically deletes in 2 minutes so save or forward it now.",
+        )
+        if isinstance(done, types.Error):
+            await reply.edit_text(f"❌ Error: {done.message}")
+        else:
+            await reply.delete()
+            async def delete_message():
+                await done.delete()
+            c.loop.call_later(120, lambda: asyncio.create_task(delete_message()))
+    finally:
+        try:
+            os.remove(downloaded_path)
+        except Exception as e:
+            c.logger.error(f"Error deleting file {downloaded_path}: {e}")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,15 +1,17 @@
 from ._api import ApiData, HttpClient
-from ._cache import shortener, upload_cache
+from ._cache import shortener
 from ._downloader import Download, download_playlist_zip
 from ._filters import Filter
 from ._dataclass import APIResponse
+from ._db import db
+
 __all__ = [
     "ApiData",
     "Download",
     "Filter",
     "download_playlist_zip",
     "shortener",
-    "upload_cache",
     "APIResponse",
-    "HttpClient"
+    "HttpClient",
+    "db"
 ]

--- a/src/utils/_cache.py
+++ b/src/utils/_cache.py
@@ -1,23 +1,7 @@
 import hashlib
 from threading import RLock
 from typing import Dict, Optional
-from collections import OrderedDict
 
-# TODO: use mongo
-class UploadCache:
-    def __init__(self):
-        self.cache = OrderedDict()
-
-    def get(self, key: str) -> str | None:
-        return self.cache.get(key)
-
-    def set(self, key: str, file_id: str) -> None:
-        self.cache[key] = file_id
-        self.cache.move_to_end(key)
-        if len(self.cache) > 2000:
-            self.cache.popitem(last=False)
-
-upload_cache = UploadCache()
 
 class URLShortener:
     def __init__(self):

--- a/src/utils/_db.py
+++ b/src/utils/_db.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 from pymongo import AsyncMongoClient
 from pytdbot import types
@@ -96,6 +97,10 @@ class MongoDB:
             return None
 
         await self.store_song_link(track.tc, public_link.link)
+        try:
+            os.remove(file_path)
+        except Exception as e:
+            client.logger.warning(f"❌ Failed to remove file: {e}")
         return upload.content.audio.audio.remote.id
 
     async def close(self) -> None:

--- a/src/utils/_db.py
+++ b/src/utils/_db.py
@@ -1,0 +1,108 @@
+from typing import Optional
+from pymongo import AsyncMongoClient
+from pytdbot import types
+from src.config import MONGO_URI, LOGGER_ID
+from ._dataclass import TrackInfo
+
+class MongoDB:
+    def __init__(self):
+        self.mongo_client = AsyncMongoClient(MONGO_URI)
+        self._db = self.mongo_client["SpTube"]
+        self.songs = self._db["songs"]
+        self.logger_chat_id = LOGGER_ID
+        self._cache: dict[str, str] = {}
+
+    async def connect(self) -> None:
+        """Establish connection to MongoDB and load cache."""
+        await self.mongo_client.aconnect()
+        try:
+            await self.mongo_client.admin.command("ping")
+        except Exception as e:
+            raise e
+        await self._load_cache()
+
+    async def _load_cache(self) -> None:
+        """Load all stored songs into in-memory cache."""
+        async for song in self.songs.find():
+            self._cache[song["_id"]] = song["link"]
+
+    async def store_song_link(self, track_id: str, link: str) -> None:
+        """Store or update a song link in MongoDB and cache."""
+        await self.songs.update_one({"_id": track_id}, {"$set": {"link": link}}, upsert=True)
+        self._cache[track_id] = link
+
+    async def get_song_link(self, track_id: str) -> Optional[str]:
+        """Retrieve song link from cache or MongoDB."""
+        if track_id in self._cache:
+            return self._cache[track_id]
+
+        song = await self.songs.find_one({"_id": track_id})
+        if song:
+            self._cache[track_id] = song["link"]
+            return song["link"]
+        return None
+
+    async def get_song_file_id(self, track_id: str) -> Optional[str]:
+        """Retrieve the Telegram file ID for a stored song link."""
+        from src import client
+
+        link = await self.get_song_link(track_id)
+        if not link:
+            return None
+
+        info = await client.getMessageLinkInfo(url=link)
+        if isinstance(info, types.Error) or not info.message:
+            client.logger.warning(f"❌ Failed to get message link info: {getattr(info, 'message', info)}")
+            return None
+
+        msg = await client.getMessage(info.chat_id, info.message.id)
+        if isinstance(msg, types.Error):
+            client.logger.warning(f"❌ Failed to get message: {msg.message}")
+            return None
+
+        content = msg.content
+        if isinstance(content, types.MessageAudio):
+            return content.audio.audio.remote.id
+        elif isinstance(content, types.MessageDocument):
+            return content.document.document.remote.id
+        elif isinstance(content, types.MessageVideo):
+            return content.video.video.remote.id
+
+        client.logger.warning(f"❌ Unsupported media type in stored link: {content}")
+        return None
+
+    async def upload_song_and_get_file_id(
+        self, file_path: str, cover: Optional[str], track: TrackInfo
+    ) -> Optional[str]:
+        """Upload song to logger chat, store link, and return file ID."""
+        from src import client
+
+        upload = await client.sendAudio(
+            chat_id=self.logger_chat_id,
+            audio=types.InputFileLocal(file_path),
+            album_cover_thumbnail=types.InputThumbnail(types.InputFileLocal(cover)) if cover else None,
+            title=track.name,
+            performer=track.artist,
+            duration=track.duration,
+            caption=f"<b>{track.name}</b>\n<i>{track.artist}</i>",
+        )
+        if isinstance(upload, types.Error):
+            client.logger.warning(f"❌ Failed to upload audio: {upload.message}")
+            return None
+
+        public_link = await client.getMessageLink(upload.chat_id, upload.id)
+        if isinstance(public_link, types.Error):
+            client.logger.warning(f"❌ Failed to get public link: {public_link.message}")
+            return None
+
+        await self.store_song_link(track.tc, public_link.link)
+        return upload.content.audio.audio.remote.id
+
+    async def close(self) -> None:
+        """Close MongoDB connection and clear cache."""
+        await self.mongo_client.aclose()
+        self._cache.clear()
+
+
+# Global DB instance
+db: MongoDB = MongoDB()

--- a/src/utils/_downloader.py
+++ b/src/utils/_downloader.py
@@ -39,7 +39,7 @@ class InvalidHexKeyError(Exception):
 class Download:
     def __init__(self, track: Optional[TrackInfo]):
         self.track = track
-        self.downloads_dir = Path(config.DOWNLOAD_PATH)
+        self.downloads_dir = config.DOWNLOAD_PATH
         self.downloads_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
         self.output_file = self.downloads_dir / f"{self._sanitize_filename(self.track.name)}.ogg"
 
@@ -338,7 +338,7 @@ class Download:
 
 async def download_playlist_zip(playlist: PlatformTracks) -> Optional[str]:
     """Optimized playlist download with parallel processing."""
-    downloads_dir = Path(config.DOWNLOAD_PATH)
+    downloads_dir = config.DOWNLOAD_PATH
     zip_path = downloads_dir / f"playlist_{int(time.time())}.zip"
     temp_dir = downloads_dir / f"tmp_{uuid.uuid4()}"
     temp_dir.mkdir(parents=True, exist_ok=True)

--- a/src/utils/_downloader.py
+++ b/src/utils/_downloader.py
@@ -133,7 +133,7 @@ class Download:
             with file_path.open('rb') as f:
                 return cipher.decrypt(f.read())
         except binascii.Error as e:
-            raise InvalidHexKeyError(f"Invalid hex key: {e}")
+            raise InvalidHexKeyError(f"Invalid hex key: {e}") from e
 
     @staticmethod
     async def rebuild_ogg(filename: Path) -> None:
@@ -187,8 +187,8 @@ class Download:
 
             if proc.returncode != 0:
                 raise Exception(f"ffmpeg failed: {stderr.decode()}")
-        except FileNotFoundError:
-            raise Exception("ffmpeg not found in PATH")
+        except FileNotFoundError as e:
+            raise Exception("ffmpeg not found in PATH") from e
 
     async def _add_vorbis_comments(self, output_file: Path) -> None:
         """Optimized vorbis comment addition."""
@@ -200,10 +200,10 @@ class Download:
             f"ALBUM={self.track.album}",
             f"ARTIST={self.track.artist}",
             f"TITLE={self.track.name}",
-            f"GENRE=Spotify @FallenProjects",
+            "GENRE=Spotify @FallenProjects",
             f"YEAR={self.track.year}",
             f"TRACKNUMBER={self.track.tc}",
-            f"COMMENT=By @FallenProjects",
+            "COMMENT=By @FallenProjects",
             f"PUBLISHER={self.track.artist}",
             f"DURATION={self.track.duration}",
         ]
@@ -344,10 +344,10 @@ async def download_playlist_zip(playlist: PlatformTracks) -> Optional[str]:
     temp_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        tasks = []
-        for music in playlist.results:
-            tasks.append(_process_playlist_track(music, temp_dir))
-
+        tasks = [
+            _process_playlist_track(music, temp_dir)
+            for music in playlist.results
+        ]
         audio_files = await asyncio.gather(*tasks, return_exceptions=True)
         audio_files = [f for f in audio_files if isinstance(f, Path)]
 

--- a/src/utils/_filters.py
+++ b/src/utils/_filters.py
@@ -126,9 +126,6 @@ class Filter:
             if ApiData(text).is_valid():
                 return True
 
-            if re.match("^https?://", text):
-                return False
-
-            return chat_id > 0
+            return False if re.match("^https?://", text) else chat_id > 0
 
         return filters.create(filter_func)

--- a/uv.lock
+++ b/uv.lock
@@ -383,6 +383,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "tdjson" },
     { name = "ujson" },
+    { name = "yt-dlp" },
 ]
 
 [package.metadata]
@@ -395,6 +396,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "tdjson", specifier = "~=1.8.51" },
     { name = "ujson", specifier = "~=5.10.0" },
+    { name = "yt-dlp", specifier = ">=2025.7.21" },
 ]
 
 [[package]]
@@ -491,4 +493,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/24/fd/725b8e73ac2a50e78a4534ac43c6addf5c1c2d65380dd48a9169cc6739a9/yarl-1.20.1-cp313-cp313t-win32.whl", hash = "sha256:b121ff6a7cbd4abc28985b6028235491941b9fe8fe226e6fdc539c977ea1739d", size = 86591, upload-time = "2025-06-10T00:45:25.793Z" },
     { url = "https://files.pythonhosted.org/packages/94/c3/b2e9f38bc3e11191981d57ea08cab2166e74ea770024a646617c9cddd9f6/yarl-1.20.1-cp313-cp313t-win_amd64.whl", hash = "sha256:541d050a355bbbc27e55d906bc91cb6fe42f96c01413dd0f4ed5a5240513874f", size = 93003, upload-time = "2025-06-10T00:45:27.752Z" },
     { url = "https://files.pythonhosted.org/packages/b4/2d/2345fce04cfd4bee161bf1e7d9cdc702e3e16109021035dbb24db654a622/yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77", size = 46542, upload-time = "2025-06-10T00:46:07.521Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2025.7.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/3a/343f7a0024ddd4c30f150e8d8f57fd7b924846f97d99fc0dcd75ea8d2773/yt_dlp-2025.7.21.tar.gz", hash = "sha256:46fbb53eab1afbe184c45b4c17e9a6eba614be680e4c09de58b782629d0d7f43", size = 3050219, upload-time = "2025-07-21T23:59:03.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2f/abe59a3204c749fed494849ea29176bcefa186ec8898def9e43f649ddbcf/yt_dlp-2025.7.21-py3-none-any.whl", hash = "sha256:d7aa2b53f9b2f35453346360f41811a0dad1e956e70b35a4ae95039d4d815d15", size = 3288681, upload-time = "2025-07-21T23:59:01.788Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -61,28 +61,6 @@ wheels = [
 ]
 
 [[package]]
-name = "charset-normalizer"
-version = "3.4.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367, upload-time = "2025-05-02T08:34:42.01Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622, upload-time = "2025-05-02T08:32:56.363Z" },
-    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435, upload-time = "2025-05-02T08:32:58.551Z" },
-    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653, upload-time = "2025-05-02T08:33:00.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231, upload-time = "2025-05-02T08:33:02.081Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243, upload-time = "2025-05-02T08:33:04.063Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442, upload-time = "2025-05-02T08:33:06.418Z" },
-    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147, upload-time = "2025-05-02T08:33:08.183Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057, upload-time = "2025-05-02T08:33:09.986Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454, upload-time = "2025-05-02T08:33:11.814Z" },
-    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174, upload-time = "2025-05-02T08:33:13.707Z" },
-    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166, upload-time = "2025-05-02T08:33:15.458Z" },
-    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064, upload-time = "2025-05-02T08:33:17.06Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641, upload-time = "2025-05-02T08:33:18.753Z" },
-    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload-time = "2025-05-02T08:34:40.053Z" },
-]
-
-[[package]]
 name = "deepdiff"
 version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -92,6 +70,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0a/0f/9cd2624f7dcd755cbf1fa21fb7234541f19a1be96a56f387ec9053ebe220/deepdiff-8.5.0.tar.gz", hash = "sha256:a4dd3529fa8d4cd5b9cbb6e3ea9c95997eaa919ba37dac3966c1b8f872dc1cd1", size = 538517, upload-time = "2025-05-09T18:44:10.035Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/3b/2e0797200c51531a6d8c97a8e4c9fa6fb56de7e6e2a15c1c067b6b10a0b0/deepdiff-8.5.0-py3-none-any.whl", hash = "sha256:d4599db637f36a1c285f5fdfc2cd8d38bde8d8be8636b65ab5e425b67c54df26", size = 85112, upload-time = "2025-05-09T18:44:07.784Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
 ]
 
 [[package]]
@@ -327,6 +314,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pymongo"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/1c/f148bb1747c48955dbeea34a53c6d60b858f902c61c62330d277ee806af7/pymongo-4.14.0.tar.gz", hash = "sha256:15674e3fddce78cf134fc4e55f90abf1608a48430130cd35efdf3802fd47a1d1", size = 2213509, upload-time = "2025-08-06T13:41:11.04Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/99/d6c145e57387bfa2b6d90f4f5285f2b0903625733dcc6403aa9d7abeddbb/pymongo-4.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54576faf8e6fefe17886a201f9df61bdf728ccac9a7a0847095a0e8480cd6ec1", size = 968259, upload-time = "2025-08-06T13:40:20.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/36/5226af83554bbfa0d754aa1ab022af92f64a2376604d56c9a8c50e247b85/pymongo-4.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c64ef5e58adedecb853a680eb5d1aea50770197f212e202d6eb50c801797b576", size = 967959, upload-time = "2025-08-06T13:40:21.962Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f5/4e627e3e5230e8c62c5fe218b5cb1347a1b01932fd6446c3f03e18ec29c5/pymongo-4.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f1c0cdddf9783065bf55d3fe025843c0974a828bafc9bb5514ae28dd2828a40", size = 1956074, upload-time = "2025-08-06T13:40:23.413Z" },
+    { url = "https://files.pythonhosted.org/packages/16/05/989cfdc8536245a55a549f76ba20356822ebfce752e72a5164bd0795ace0/pymongo-4.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:22805d4fa587b526ac3129ee634a8761abbeb76883045718438f5b8e72f91ce6", size = 2033427, upload-time = "2025-08-06T13:40:25.325Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a5/fafef0230fa6cc5d4bb5addcea77d8b71f4eca4d31a5a596d26398aaa45a/pymongo-4.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c3e6e669cf36b27694de2730f5d5b31ef492ffe99446563192c4e8ee84ca859", size = 1997344, upload-time = "2025-08-06T13:40:26.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/6c/1170d5c8e087832dba2b0930ec90bafde8a59efa37b521d9a5902ec9d282/pymongo-4.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9763a2477d5388df65ab6f591cf0cb7fd34f4a66f873c31e63288fd79887742c", size = 1958072, upload-time = "2025-08-06T13:40:28.865Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7b/bb07c7c4c102046ff92f3acd05d85870e06a08df2a0fcd2e87586f2516fe/pymongo-4.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88d6f5aceab3528b8760942a57635599925f7fd743691f9d759a02124207dfd0", size = 1907647, upload-time = "2025-08-06T13:40:30.435Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e6/c0ee2163133f1a437cd3b0308521e24181b69b5510b9eabde9ee86999c12/pymongo-4.14.0-cp313-cp313-win32.whl", hash = "sha256:e283feafde118cbbb03adc036b882be042b0a2eca121ec5d6bbec3e12980e8fa", size = 931673, upload-time = "2025-08-06T13:40:31.956Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/1d/1692f0696d8e6bcb3e43469999eeb92d5f0acdb9a50aca2c869820321df9/pymongo-4.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:a29b62d421a512833e99d4781b64e695cfe23b4c4a9159ea83e56fc2660f2480", size = 955893, upload-time = "2025-08-06T13:40:33.461Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/19/f3ed531d7151dc2d1be27746c206e74403283873ec5d12170616982eccb0/pymongo-4.14.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67225d5fb1be2a34c6f73cde9d81a8041a095a94ed2433e2cf9e2f1657443def", size = 1024757, upload-time = "2025-08-06T13:40:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f9/38782d41e16d11ba540ddfc618104e249a5b950a446b8a77a17f3416c6e6/pymongo-4.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bbf0dbe8554978c1271bdc82366852245a03ab124a1387b6f3531f64adac3c39", size = 1024765, upload-time = "2025-08-06T13:40:36.797Z" },
+    { url = "https://files.pythonhosted.org/packages/82/75/b385aa6ed09d077b47b00d4bc3c4b9bdac97b50fde3be7599ff9ceef8cbc/pymongo-4.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7f61561cbc7426ffc2d37b46e65ab5323fc366644f70c8e2240ed5452e2c402", size = 2284433, upload-time = "2025-08-06T13:40:38.35Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/29/d0dbf281e58e26dbeef4e972905b371c63d33c5aa8caa0d58140224bfee5/pymongo-4.14.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:502cd551679753fb7838221c3bbb963da4b4aa0576848192afb1f78128ff729a", size = 2371473, upload-time = "2025-08-06T13:40:39.852Z" },
+    { url = "https://files.pythonhosted.org/packages/db/eb/089dfc96a29881ed17964705ea254da2f8b3aebf9754abd6aaa8125e1589/pymongo-4.14.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba6b59afef2b47c4859bf36115fa577330601b93e39d04f39fcc6103e801286", size = 2330862, upload-time = "2025-08-06T13:40:41.803Z" },
+    { url = "https://files.pythonhosted.org/packages/35/07/b4f1215314e5f1114a899c33f17219b1f590502c736058c50571fa189ed1/pymongo-4.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c0fa103f978c15f7c2f0d7b2e010c24c327432a0310503bc0ec93c5f9be9e81", size = 2282058, upload-time = "2025-08-06T13:40:43.467Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a1/87340e5a38003ef3591fdfc4b911fb32531b0dbbed8ab2431006858590fe/pymongo-4.14.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5fe93676afe37794f01b8df5cf16528dce4d7d174cdf51ea1586c234eb5263c2", size = 2221380, upload-time = "2025-08-06T13:40:45.256Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/68/3970d18b0b58c4681598bc1e233f33c15ff0c388422b17ddd195e214f35d/pymongo-4.14.0-cp313-cp313t-win32.whl", hash = "sha256:1462fc2bb39527f01eea5378172b66c45d62e22fa4be957afe2ec747c4d2ff51", size = 980892, upload-time = "2025-08-06T13:40:46.908Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fa/68b1555e62ed3ee87f8a2de99d5fb840cf045748da4488870b4dced44a95/pymongo-4.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e506af9b25aac77cc5c5ea4a72f81764e4f5ea90ca799aac43d665ab269f291d", size = 1011181, upload-time = "2025-08-06T13:40:48.641Z" },
+]
+
+[[package]]
 name = "pytdbot"
 version = "0.9.5"
 source = { registry = "https://pypi.org/simple" }
@@ -346,21 +362,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.32.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
-]
-
-[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -377,9 +378,9 @@ dependencies = [
     { name = "httpx" },
     { name = "pycryptodome" },
     { name = "pydantic" },
+    { name = "pymongo" },
     { name = "pytdbot" },
     { name = "python-dotenv" },
-    { name = "requests" },
     { name = "tdjson" },
     { name = "ujson" },
 ]
@@ -389,9 +390,9 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pycryptodome", specifier = ">=3.23.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pymongo", specifier = ">=4.14.0" },
     { name = "pytdbot", specifier = ">=0.9.5" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
-    { name = "requests", specifier = "~=2.32.4" },
     { name = "tdjson", specifier = "~=1.8.51" },
     { name = "ujson", specifier = "~=5.10.0" },
 ]
@@ -442,15 +443,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/45/ed/582c4daba0f3e1688d923b5cb914ada1f9defa702df38a1916c899f7c4d1/ujson-5.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9500e61fce0cfc86168b248104e954fead61f9be213087153d272e817ec7b4f", size = 1043580, upload-time = "2024-05-14T02:01:31.447Z" },
     { url = "https://files.pythonhosted.org/packages/d7/0c/9837fece153051e19c7bade9f88f9b409e026b9525927824cdf16293b43b/ujson-5.10.0-cp313-cp313-win32.whl", hash = "sha256:4c4fc16f11ac1612f05b6f5781b384716719547e142cfd67b65d035bd85af165", size = 38766, upload-time = "2024-05-14T02:01:32.856Z" },
     { url = "https://files.pythonhosted.org/packages/d7/72/6cb6728e2738c05bbe9bd522d6fc79f86b9a28402f38663e85a28fddd4a0/ujson-5.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:4573fd1695932d4f619928fd09d5d03d917274381649ade4328091ceca175539", size = 42212, upload-time = "2024-05-14T02:01:33.97Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Use MongoDB for persistent caching of downloaded media, refactor inline and callback handlers to leverage remote file IDs, and introduce a new `/yt` command powered by yt-dlp for YouTube downloads with cookie and proxy management

New Features:
- Integrate MongoDB to cache and retrieve Telegram file IDs for previously downloaded tracks
- Add `/yt` command backed by yt-dlp for downloading YouTube videos with cookie and proxy support

Enhancements:
- Refactor callback and inline flows to use remote file IDs from the DB cache instead of local redownloads
- Validate required config keys at startup and manage DB connection lifecycle on bot start/stop
- Consolidate help menu handling into a shared utility and improve various error messages
- Replace in-memory upload cache with persistent DB storage and switch inline callbacks to use uuid4 for result IDs
- Update default download path, add COOKIES_URL support, and clean up dependency list